### PR TITLE
Update bitly version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "expresso"
   },
   "dependencies": {
-    "bitly": "1.0.1"
+    "bitly": "1.1.2"
   },
   "bundleDependencies": [
     "bitly"


### PR DESCRIPTION
Update bitly version dependency, as 1.0.8 is no longer available via NPM, essentially breaking this module.
